### PR TITLE
Add Himalayas as job board

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@
 
 ### [AngelList](https://angel.co/jobs)
 
+### [Himalayas](https://himalayas.app)
+
 ### [Jr.DevJobs](http://www.jrdevjobs.com)
 
 ### [Freshjobs](http://freshjobs.ch/)


### PR DESCRIPTION
Added https://himalayas.app as a job board. Himalayas has a significant proportion of front-end developer jobs (and developer jobs overall) which you can find here: https://himalayas.app/jobs/front-end-developer

Himalayas is a remote job board that offers a large range of remote-specific filters, jobs, and company profiles, including information about company tech stacks and benefits. It is free for job seekers to use to find remote jobs.